### PR TITLE
add pre-request and pre-response handlers

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -109,6 +109,9 @@ function eachHeader (obj, fn) {
  */
 
 function onrequest (req, res) {
+  var self = this;
+  self.emit('proxyRequest', req);
+
   debug.request('%s %s HTTP/%s ', req.method, req.url, req.httpVersion);
   var server = this;
   var socket = req.socket;
@@ -209,6 +212,7 @@ function onrequest (req, res) {
     debug.proxyRequest('%s %s HTTP/1.1 ', proxyReq.method, proxyReq.path);
 
     proxyReq.on('response', function (proxyRes) {
+      self.emit('proxyResponse', req, proxyRes);
       debug.proxyResponse('HTTP/1.1 %s', proxyRes.statusCode);
       gotResponse = true;
 


### PR DESCRIPTION
It's should be useful to be able to catch (or change) requests and
responses:

server.on('proxyRequest', function(req){
  req.url = 'http://change_anything_eg/';
});
server.on('proxyResponse', function(req, resp){
  resp.headers.change_header_eg = 'true';
});
