### PR TITLE
feat: local-address option for outgoing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ $ proxy --authenticate 'if \
     exit 1;'
 ```
 
+#### Custom outgoing interface
+
+Pass the `-l`/`--local-address` argument with an IP address of the network
+interface to send the outgoing requests through. It is the equivalent of setting
+a `localAddress` field in the options when calling `http.request()`.
+
+``` bash
+$ proxy --local-address 192.168.0.10
+```
 
 License
 -------

--- a/bin/proxy
+++ b/bin/proxy
@@ -13,6 +13,7 @@ program
   .version(version)
   .option('-p, --port <n>', 'TCP port number to bind to. Defaults to 3128', 3128, Number)
   .option('-a, --authenticate <command>', '"authenticate" command to run when "Proxy-Authorization" is given')
+  .option('-l, --local-address <ip>', 'IP address of the network interface to send the outgoing requests through')
   .parse(process.argv);
 
 var http = require('http');
@@ -34,6 +35,12 @@ setup(proxy);
 
 debug('setting outbound proxy request\'s `agent` to `false`');
 proxy.agent = false;
+
+/**
+ * Proxy outgoing request localAddress parameter
+ */
+
+if (program.localAddress) proxy.localAddress = program.localAddress;
 
 /**
  * Proxy authenticate function.

--- a/proxy.js
+++ b/proxy.js
@@ -203,6 +203,8 @@ function onrequest (req, res) {
       res.end('Only "http:" protocol prefix is supported\n');
       return;
     }
+    
+    if (server.localAddress) parsed.localAddress = server.localAddress;
 
     var gotResponse = false;
     var proxyReq = http.request(parsed);


### PR DESCRIPTION
Proven incredibly useful to me, so I thought I'd pass it along. Does exactly what it says it does, sets the `localAddress` parameter of the options passed to the `http.request()` method.
