### PR TITLE
Do not remove the event listeners of the sockets

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -347,7 +347,6 @@ function onconnect (req, socket, head) {
     res = null;
 
     socket.pipe(target);
-    target.once('unpipe', resume);
     target.pipe(socket);
   }
 
@@ -397,17 +396,6 @@ function onconnect (req, socket, head) {
     target.on('error', ontargeterror);
     target.on('end', ontargetend);
   });
-}
-
-/**
- * Resumes a socket.
- *
- * @param {(net.Socket|tls.Socket)} socket The socket to resume
- * @api private
- */
-
-function resume (socket) {
-  socket.resume();
 }
 
 /**

--- a/proxy.js
+++ b/proxy.js
@@ -292,36 +292,30 @@ function onconnect (req, socket, head) {
   var gotResponse = false;
 
   // define request socket event listeners
-  function onclientclose (err) {
+  socket.on('close', function onclientclose () {
     debug.request('HTTP request %s socket "close" event', req.url);
-  }
-  socket.on('close', onclientclose);
+  });
 
-  function onclientend () {
+  socket.on('end', function onclientend () {
     debug.request('HTTP request %s socket "end" event', req.url);
-    cleanup();
-  }
+  });
 
-  function onclienterror (err) {
+  socket.on('error', function onclienterror (err) {
     debug.request('HTTP request %s socket "error" event:\n%s', req.url, err.stack || err);
-  }
-  socket.on('error', onclienterror);
+  });
 
   // define target socket event listeners
   function ontargetclose () {
     debug.proxyResponse('proxy target %s "close" event', req.url);
-    cleanup();
     socket.destroy();
   }
 
   function ontargetend () {
     debug.proxyResponse('proxy target %s "end" event', req.url);
-    cleanup();
   }
 
   function ontargeterror (err) {
     debug.proxyResponse('proxy target %s "error" event:\n%s', req.url, err.stack || err);
-    cleanup();
     if (gotResponse) {
       debug.response('already sent a response, just destroying the socket...');
       socket.destroy();
@@ -355,20 +349,6 @@ function onconnect (req, socket, head) {
     socket.pipe(target);
     target.once('unpipe', resume);
     target.pipe(socket);
-  }
-
-  // cleans up event listeners for the `socket` and `target` sockets
-  function cleanup () {
-    debug.response('cleanup');
-    socket.removeListener('close', onclientclose);
-    socket.removeListener('error', onclienterror);
-    socket.removeListener('end', onclientend);
-    if (target) {
-      target.removeListener('connect', ontargetconnect);
-      target.removeListener('close', ontargetclose);
-      target.removeListener('error', ontargeterror);
-      target.removeListener('end', ontargetend);
-    }
   }
 
   // create the `res` instance for this request since Node.js

--- a/test/test.js
+++ b/test/test.js
@@ -108,49 +108,6 @@ describe('proxy', function () {
     });
   });
 
-  it('should resume the client socket when it is unpiped', function (done) {
-    server.once('request', function (req, res) {
-      res.end();
-    });
-
-    var gotData = false;
-    var host = '127.0.0.1:' + serverPort;
-    var socket = net.connect({ port: proxyPort });
-
-    socket.on('connect', function () {
-      socket.write(
-        'CONNECT ' + host + ' HTTP/1.1\r\n' +
-        'Host: ' + host + '\r\n' +
-        '\r\n'
-      );
-    });
-
-    socket.on('close', function () {
-      assert(gotData);
-      done();
-    });
-
-    socket.setEncoding('utf8');
-    socket.once('data', function (data) {
-      assert(0 == data.indexOf('HTTP/1.1 200 Connection established\r\n'));
-
-      socket.write(
-        'POST / HTTP/1.1\r\n' +
-        'Host: ' + host + '\r\n' +
-        'Connection: close\r\n' +
-        'Transfer-Encoding: chunked\r\n' +
-        '\r\n'
-      );
-
-      socket.once('data', function (data) {
-        assert(0 == data.indexOf('HTTP/1.1 200 OK\r\n'));
-        gotData = true;
-        socket.write('10\r\n{ "foo": "bar",\r\n');
-      });
-    });
-  });
-
-
   describe('authentication', function () {
     function clearAuth () {
       delete proxy.authenticate;


### PR DESCRIPTION
This should deflake tests on [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent).

First commit:

```
Do not remove the event listeners of the sockets

Sockets are not reused so the listeners should be GC'ed when the sockets
are closed. Furthermore there are cases where the `'error'` listeners
are prematurely removed leading to unhandled errors and unexpected
crashes.

Refs: https://github.com/TooTallNate/node-https-proxy-agent/pull/79
```

Second commit:

```
Partially revert 58ed8f061e8f0ae05cde3ecdcebc9e58502214b4

Resuming the client socket is no longer needed as it is destroyed when
the target socket emits `'close'`.
```